### PR TITLE
Remove call to finish

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -19,4 +19,6 @@
         </activity>
     </application>
     <uses-permission android:name="android.permission.DISABLE_KEYGUARD"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
 </manifest>

--- a/src/io/appium/unlock/Unlock.java
+++ b/src/io/appium/unlock/Unlock.java
@@ -1,9 +1,10 @@
 package io.appium.unlock;
 
-import android.app.*;
-import android.content.*;
-import android.os.*;
-import android.view.*;
+import android.app.Activity;
+import android.app.KeyguardManager;
+import android.os.Bundle;
+import android.view.Window;
+import android.view.WindowManager;
 
 public class Unlock extends Activity
 {
@@ -11,24 +12,17 @@ public class Unlock extends Activity
     public void onCreate(Bundle savedInstanceState)
     {
         super.onCreate(savedInstanceState);
+
         // Set window flags to unlock screen. This works on most devices by itself.
         Window window = this.getWindow();
         window.addFlags(WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED);
         window.addFlags(WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON);
         window.addFlags(WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD);
 
-        // On most other devices, using the KeyguardManager + the permission in 
+        // On most other devices, using the KeyguardManager + the permission in
         // AndroidManifest.xml will do the trick
         KeyguardManager mKeyGuardManager = (KeyguardManager) getSystemService(KEYGUARD_SERVICE);
         KeyguardManager.KeyguardLock mLock = mKeyGuardManager.newKeyguardLock("Unlock");
         mLock.disableKeyguard();
-
-        // Close yourself!
-        Handler handler = new Handler();
-        handler.postDelayed(new Runnable() {
-            public void run() {
-                Unlock.this.finish();
-            }
-        }, 200);
     }
 }


### PR DESCRIPTION
Remove call to `Activity#finish`, which may be the cause of an issue in which the Activity gets destroyed during runs on real devices. The app functions without the call.

Also make explicit permissions which the vm was adding during execution.
