### PR TITLE
Move the unlock app to back from within the app itself

### DIFF
--- a/src/io/appium/unlock/Unlock.java
+++ b/src/io/appium/unlock/Unlock.java
@@ -12,10 +12,8 @@ public class Unlock extends Activity
     public void onCreate(Bundle savedInstanceState)
     {
         super.onCreate(savedInstanceState);
-
         // Set window flags to unlock screen. This works on most devices by itself.
         Window window = this.getWindow();
-        window.addFlags(WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED);
         window.addFlags(WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON);
         window.addFlags(WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD);
 
@@ -24,5 +22,12 @@ public class Unlock extends Activity
         KeyguardManager mKeyGuardManager = (KeyguardManager) getSystemService(KEYGUARD_SERVICE);
         KeyguardManager.KeyguardLock mLock = mKeyGuardManager.newKeyguardLock("Unlock");
         mLock.disableKeyguard();
+    }
+
+    @Override
+    protected void onPostCreate(Bundle savedInstanceState) 
+    {
+        super.onPostCreate(savedInstanceState);
+        moveTaskToBack(true);
     }
 }


### PR DESCRIPTION
Sometimes after unlock we were seeing the locking screen come back up, when sending it to back right after unlocking `appium-android-driver` successfully checks that screen is unlocked without creating false positives.

Changes made: 
* Send app to background after unlocking 
* Remove a flag that makes appium test run even if it didn't unlock