### PR TITLE
Add unlock support for devices with screen backlight off

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -3,6 +3,10 @@
       package="io.appium.unlock"
       android:versionCode="1"
       android:versionName="1.0">
+    <uses-sdk android:minSdkVersion="5"/>
+    <uses-permission android:name="android.permission.DISABLE_KEYGUARD"/>
+    <uses-permission android:name="android.permission.WAKE_LOCK"/>
+    <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
     <application android:label="@string/app_name" android:icon="@drawable/ic_launcher">
         <activity android:name="Unlock"
           android:label="@string/app_name"
@@ -18,7 +22,4 @@
             </intent-filter>
         </activity>
     </application>
-    <uses-permission android:name="android.permission.DISABLE_KEYGUARD"/>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-    <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
 </manifest>

--- a/src/io/appium/unlock/Unlock.java
+++ b/src/io/appium/unlock/Unlock.java
@@ -2,7 +2,9 @@ package io.appium.unlock;
 
 import android.app.Activity;
 import android.app.KeyguardManager;
+import android.content.Context;
 import android.os.Bundle;
+import android.os.PowerManager;
 import android.view.Window;
 import android.view.WindowManager;
 
@@ -14,14 +16,27 @@ public class Unlock extends Activity
         super.onCreate(savedInstanceState);
         // Set window flags to unlock screen. This works on most devices by itself.
         Window window = this.getWindow();
+        window.addFlags(WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED);
         window.addFlags(WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON);
         window.addFlags(WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD);
+
+        // some devices needs waking up screen first before disable keyguard
+        PowerManager powerManager = (PowerManager) getSystemService(Context.POWER_SERVICE);
+        PowerManager.WakeLock screenLock = powerManager.newWakeLock(PowerManager.ACQUIRE_CAUSES_WAKEUP | PowerManager.SCREEN_DIM_WAKE_LOCK, "");
+        screenLock.acquire();
+
+        if (screenLock.isHeld()) {
+            screenLock.release();
+        }
 
         // On most other devices, using the KeyguardManager + the permission in
         // AndroidManifest.xml will do the trick
         KeyguardManager mKeyGuardManager = (KeyguardManager) getSystemService(KEYGUARD_SERVICE);
-        KeyguardManager.KeyguardLock mLock = mKeyGuardManager.newKeyguardLock("Unlock");
-        mLock.disableKeyguard();
+        if (mKeyGuardManager.inKeyguardRestrictedInputMode()) {
+            KeyguardManager.KeyguardLock keyguardLock = mKeyGuardManager.newKeyguardLock("Unlock");
+            keyguardLock.disableKeyguard();
+        }
+
     }
 
     @Override

--- a/src/io/appium/unlock/Unlock.java
+++ b/src/io/appium/unlock/Unlock.java
@@ -22,7 +22,7 @@ public class Unlock extends Activity
 
         // some devices needs waking up screen first before disable keyguard
         PowerManager powerManager = (PowerManager) getSystemService(Context.POWER_SERVICE);
-        PowerManager.WakeLock screenLock = powerManager.newWakeLock(PowerManager.ACQUIRE_CAUSES_WAKEUP | PowerManager.SCREEN_DIM_WAKE_LOCK, "");
+        PowerManager.WakeLock screenLock = powerManager.newWakeLock(PowerManager.ACQUIRE_CAUSES_WAKEUP | PowerManager.SCREEN_DIM_WAKE_LOCK, getLocalClassName());
         screenLock.acquire();
 
         if (screenLock.isHeld()) {
@@ -33,7 +33,7 @@ public class Unlock extends Activity
         // AndroidManifest.xml will do the trick
         KeyguardManager mKeyGuardManager = (KeyguardManager) getSystemService(KEYGUARD_SERVICE);
         if (mKeyGuardManager.inKeyguardRestrictedInputMode()) {
-            KeyguardManager.KeyguardLock keyguardLock = mKeyGuardManager.newKeyguardLock("Unlock");
+            KeyguardManager.KeyguardLock keyguardLock = mKeyGuardManager.newKeyguardLock(getLocalClassName());
             keyguardLock.disableKeyguard();
         }
 


### PR DESCRIPTION
- Some devices could not be unlocked when screen backlight is off. Added code to wake up screen before disabling keyguard. (e.g. Xiaomi MI3 with MiUI 7 v6.5.19 dev version)
- `WindowManager.LayoutParams` flags used in code are after sdk version 5, added `minSDKVersion` in manifest; changed order of permission declaration in manifest
- use `getLocalClassName` for tag usage in code