### PR TITLE
Stop activity after unlock

### DIFF
--- a/src/io/appium/unlock/Unlock.java
+++ b/src/io/appium/unlock/Unlock.java
@@ -45,4 +45,10 @@ public class Unlock extends Activity
         super.onPostCreate(savedInstanceState);
         moveTaskToBack(true);
     }
+    
+    @Override
+    protected void onStop() {
+        super.onStop();
+        finish();
+    }
 }


### PR DESCRIPTION
If tests execution was interrupted / appium crashed - unlock activity will be not closed. On the next run after adb shell am start -n io.appium.unlock/.Unlock activity will be restored to foreground and we will see only black screen. This cause tests to fail and require manual work to stop unlock.
Also on some devices it never worked before this patch (even 1st run cause black screen with activity in foreground).